### PR TITLE
Fix use of plenary job to use on_exit callback

### DIFF
--- a/lua/json2struct/init.lua
+++ b/lua/json2struct/init.lua
@@ -1,24 +1,45 @@
-local json2struct = require("json2struct.json2struct")
-
-local M = {}
-
 local function lines_between(line1, line2)
 	local lines = vim.api.nvim_buf_get_lines(0, line1, line2, false)
 	return table.concat(lines, "\n")
 end
 
-function M.setup()
-	vim.api.nvim_create_user_command("JSON2Struct", function(opts)
-		local json = lines_between(opts.line1 - 1, opts.line2)
-		local struct = json2struct(json)
+local function json2struct(name, first, last)
+	name = name or vim.fn.input("Struct name: ")
+	local json = lines_between(first, last)
 
-		local lines = {}
-		for line in struct:gmatch("[^\r\n]+") do
-			table.insert(lines, line)
-		end
+	if vim.json.decode(json) == nil then
+		vim.notify("Invalid JSON", vim.log.levels.ERROR)
+		return
+	end
 
-		vim.api.nvim_buf_set_lines(0, opts.line1 - 1, opts.line2, false, lines)
-	end, { range = true })
+	local Job = require("plenary.job")
+	Job:new({
+		command = "json2struct",
+		args = { "-name=" .. name },
+		writer = json,
+		on_exit = function(job, exit_code)
+			if exit_code ~= 0 then
+				vim.notify("Error generating struct: exit " .. exit_code, vim.log.levels.ERROR)
+				return
+			end
+
+			local struct = job:result()
+			if not assert(struct) or #struct == 0 then
+				vim.notify("Error generating struct", vim.log.levels.ERROR)
+				return
+			end
+
+			vim.schedule(function()
+				vim.api.nvim_buf_set_lines(0, first, last, false, struct)
+			end)
+		end,
+	}):start()
 end
 
-return M
+return {
+	setup = function()
+		vim.api.nvim_create_user_command("JSON2Struct", function(opts)
+			json2struct(opts.fargs[1], opts.line1 - 1, opts.line2)
+		end, { nargs = "?", range = true })
+	end,
+}

--- a/lua/json2struct/json2struct.lua
+++ b/lua/json2struct/json2struct.lua
@@ -1,12 +1,12 @@
 local Job = require("plenary.job")
 
-return function(json, name)
+return function(json, name, on_exit)
 	name = name or "JSON"
 
-	local job = Job:new({
+	Job:new({
 		command = "json2struct",
 		args = { "-name=" .. name },
 		writer = json,
-	}):sync()
-	return table.concat(job, "\n")
+		on_exit = on_exit,
+	}):start()
 end


### PR DESCRIPTION
Previously, there was a race condition where the job could be running
when trying to write the struct to the buffer.